### PR TITLE
Enhance home page with hero banner and promo popup

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,3 +11,50 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Tags:
 Text Domain: block-theme
 */
+
+.home-top-menu .wp-block-button__link {
+    transition: background-color 0.3s ease, transform 0.3s ease;
+    border-radius: 8px;
+}
+
+.home-top-menu .wp-block-button__link:hover {
+    background-color: var(--wp--preset--color--primary);
+    color: var(--wp--preset--color--background);
+    transform: scale(1.05);
+}
+
+.hero-banner {
+    background-image: url('screenshot.png');
+    background-size: cover;
+    background-position: center;
+    width: 100%;
+    height: 450px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: -1;
+}
+
+.home-top-menu,
+main {
+    margin-top: 450px;
+}
+
+.promo-popup {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background-color: var(--wp--preset--color--background, #fff);
+    padding: 1rem 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    z-index: 1000;
+}
+
+.promo-popup button {
+    background: none;
+    border: none;
+    font-size: 1rem;
+    margin-left: 1rem;
+    cursor: pointer;
+}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,5 +1,27 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
+<div class="hero-banner"></div>
+
+<!-- wp:group {"align":"wide","className":"home-top-menu"} -->
+<div class="wp-block-group alignwide home-top-menu">
+    <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+    <div class="wp-block-buttons">
+        <!-- wp:button -->
+        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Who we are</a></div>
+        <!-- /wp:button -->
+
+        <!-- wp:button -->
+        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Latest projects</a></div>
+        <!-- /wp:button -->
+
+        <!-- wp:button -->
+        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Contact</a></div>
+        <!-- /wp:button -->
+    </div>
+    <!-- /wp:buttons -->
+</div>
+<!-- /wp:group -->
+
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--70)">
 	<!-- wp:site-title {"style":{"spacing":{"margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}}, "align":"wide"} /-->
@@ -31,5 +53,21 @@
 	<!-- wp:pattern {"slug":"block-theme/call-to-action"} /-->
 </main>
 <!-- /wp:group -->
+
+<div id="promo-popup" class="promo-popup">
+    <span>25% off for your SEO boost!</span>
+    <button id="promo-close">×</button>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const popup = document.getElementById('promo-popup');
+    const close = document.getElementById('promo-close');
+    const timer = setTimeout(() => popup.style.display = 'none', 5000);
+    close.addEventListener('click', function() {
+        popup.style.display = 'none';
+        clearTimeout(timer);
+    });
+});
+</script>
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
## Summary
- add full-width fixed hero banner behind content
- soften menu button corners
- introduce dismissible promo popup that hides after 5 seconds

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9315d505c832da440df7d958411d4