### PR TITLE
Customize navigation and home page layout

### DIFF
--- a/parts/header.html
+++ b/parts/header.html
@@ -3,7 +3,11 @@
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 	<div class="wp-block-group alignwide" style="padding-bottom:var(--wp--preset--spacing--40)">
 		<!-- wp:site-title {"level":0} /-->
-		<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /-->
+                <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
+                <!-- wp:navigation-link {"label":"Home","url":"/","kind":"custom","isTopLevelLink":true} /-->
+                <!-- wp:navigation-link {"label":"Our Work","url":"/our-work","kind":"custom","isTopLevelLink":true} /-->
+                <!-- wp:navigation-link {"label":"Agency","url":"/agency","kind":"custom","isTopLevelLink":true} /-->
+                <!-- /wp:navigation -->
 	</div>
 	<!-- /wp:group -->
 </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,35 +1,45 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--70)">
-	<!-- wp:site-title {"style":{"spacing":{"margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}}, "align":"wide"} /-->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+    <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+    <figure class="wp-block-image size-large"><img src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f" alt="Woman working at a computer"/></figure>
+    <!-- /wp:image -->
 
-	<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->
-	<div class="wp-block-query alignwide">
-		<!-- wp:post-template {"align":"wide"} -->
-			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"clamp(15vw, 30vh, 400px)","align":"wide"} /-->
-			<!-- wp:post-title {"isLink":true} /-->
-			<!-- wp:post-excerpt /-->
-			<!-- wp:post-date {"isLink":true} /-->
+    <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+    <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)">
+        <!-- wp:heading -->
+        <h2>Section One</h2>
+        <!-- /wp:heading -->
+        <!-- wp:paragraph -->
+        <p>Content for the first section.</p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
 
-			<!-- wp:spacer {"height":"var(--wp--preset--spacing--40)"} -->
-			<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
-			<!-- /wp:spacer -->
-		<!-- /wp:post-template -->
+    <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+    <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)">
+        <!-- wp:heading -->
+        <h2>Section Two</h2>
+        <!-- /wp:heading -->
+        <!-- wp:paragraph -->
+        <p>Content for the second section.</p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
 
-		<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-			<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
-			<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-		<!-- /wp:query-pagination -->
-	</div>
-	<!-- /wp:query -->
-
-	<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
-	<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
-
-	<!-- wp:pattern {"slug":"block-theme/call-to-action"} /-->
+    <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+    <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)">
+        <!-- wp:heading -->
+        <h2>Section Three</h2>
+        <!-- /wp:heading -->
+        <!-- wp:paragraph -->
+        <p>Content for the third section.</p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
 </main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+

--- a/theme.json
+++ b/theme.json
@@ -10,16 +10,16 @@
       "defaultPalette": false,
       "duotone": [],
       "palette": [
-        {
-          "name": "Background",
-          "slug": "background",
-          "color": "#FEFEFE"
-        },
-        {
-          "name": "Foreground",
-          "slug": "foreground",
-          "color": "#181A1F"
-        },
+          {
+            "name": "Background",
+            "slug": "background",
+            "color": "#E06547"
+          },
+          {
+            "name": "Foreground",
+            "slug": "foreground",
+            "color": "#FFFFFF"
+          },
         {
           "name": "Primary",
           "slug": "primary",
@@ -320,35 +320,35 @@
           "lineHeight": "1.2"
         }
       },
-      "link": {
-        ":hover": {
+        "link": {
+          ":hover": {
+            "color": {
+              "text": "var:preset|color|foreground"
+            },
+            "typography": {
+              "textDecoration": "underline var(--wp--preset--color--foreground)"
+            }
+          },
+          ":focus": {
+            "typography": {
+              "textDecoration": "underline dashed"
+            }
+          },
+          ":active": {
+            "color": {
+              "text": "var:preset|color|foreground"
+            },
+            "typography": {
+              "textDecoration": "none"
+            }
+          },
           "color": {
             "text": "var:preset|color|foreground"
           },
           "typography": {
             "textDecoration": "underline var(--wp--preset--color--foreground)"
           }
-        },
-        ":focus": {
-          "typography": {
-            "textDecoration": "underline dashed"
-          }
-        },
-        ":active": {
-          "color": {
-            "text": "var:preset|color|foreground"
-          },
-          "typography": {
-            "textDecoration": "none"
-          }
-        },
-        "color": {
-          "text": "var:preset|color|primary"
-        },
-        "typography": {
-          "textDecoration": "underline var(--wp--preset--color--primary)"
         }
-      }
     },
     "spacing": {
       "blockGap": "var:custom|block-gap",


### PR DESCRIPTION
## Summary
- add Home, Our Work, and Agency navigation links
- set theme background to `#E06547` with white text
- create simple home page with featured image and three sections
- source hero image from external URL instead of bundling JPEG

## Testing
- `composer run php-lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a939709dd8832d9267af80446aa3a2