### PR TITLE
Make home hero image full width with wave border

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,3 +11,27 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Tags:
 Text Domain: block-theme
 */
+
+/* Make images with the wave-border class span the full width and add a simple wave at the bottom */
+.wave-border {
+    position: relative;
+    overflow: hidden;
+}
+
+.wave-border img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.wave-border .wave {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 40px;
+}
+
+.wave-border .wave path {
+    fill: var(--wp--preset--color--background, #ffffff);
+}

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,8 +2,8 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-    <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-    <figure class="wp-block-image size-large"><img src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f" alt="Woman working at a computer"/></figure>
+    <!-- wp:image {"sizeSlug":"large","linkDestination":"none","align":"full","className":"wave-border"} -->
+    <figure class="wp-block-image alignfull size-large wave-border"><img src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f" alt="Woman working at a computer"/><svg class="wave" viewBox="0 0 1440 80" preserveAspectRatio="none"><path d="M0 20 C80 0 160 40 240 20 S400 0 480 20 640 40 720 20 880 0 960 20 1120 40 1200 20 1360 0 1440 20 V80 H0 Z"/></svg></figure>
     <!-- /wp:image -->
 
     <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->


### PR DESCRIPTION
## Summary
- make home template image full-width and add wave bottom border
- style wave border for responsive full-width images

## Testing
- `npm test` (fails: Missing script "test")
- `composer phpcs` (fails: PrefixAllGlobalsSniff error and missing @subpackage tag)


------
https://chatgpt.com/codex/tasks/task_e_68a93f039d0c832d99fbd63761b3faa9