### PR TITLE
Add contact, team, and project pages with navigation

### DIFF
--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -1,0 +1,52 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // Simple carousel for the Worldwide Context section.
+    document.querySelectorAll('.wt-carousel').forEach((carousel) => {
+        const slides = carousel.querySelectorAll('figure');
+        let index = 0;
+        function showSlide(i) {
+            slides.forEach((slide, idx) => {
+                slide.classList.toggle('active', idx === i);
+            });
+        }
+        if (slides.length) {
+            showSlide(index);
+            setInterval(() => {
+                index = (index + 1) % slides.length;
+                showSlide(index);
+            }, 4000);
+        }
+    });
+
+    // Animated statistics graph on the Latest Project page.
+    const stats = document.querySelectorAll('.stats-graph .stat');
+    if (stats.length) {
+        const values = Array.from(stats).map((s) => parseInt(s.dataset.value, 10));
+        const max = Math.max(...values);
+
+        stats.forEach((stat) => {
+            const value = parseInt(stat.dataset.value, 10);
+            const bar = stat.querySelector('.bar');
+            const numberEl = stat.querySelector('.stat-number');
+
+            // Animate bar height.
+            requestAnimationFrame(() => {
+                bar.style.height = (value / max) * 100 + '%';
+            });
+
+            // Animate number count up.
+            const target = parseInt(numberEl.dataset.target, 10);
+            let count = 0;
+            const step = target / 60;
+            function update() {
+                count += step;
+                if (count < target) {
+                    numberEl.textContent = Math.round(count);
+                    requestAnimationFrame(update);
+                } else {
+                    numberEl.textContent = target.toLocaleString();
+                }
+            }
+            update();
+        });
+    }
+});

--- a/src/scss/pages/_latest-project.scss
+++ b/src/scss/pages/_latest-project.scss
@@ -1,0 +1,29 @@
+.stats-graph {
+    display: flex;
+    align-items: flex-end;
+    gap: 1rem;
+    height: 200px;
+}
+
+.stats-graph .stat {
+    flex: 1;
+    text-align: center;
+}
+
+.stats-graph .bar {
+    width: 100%;
+    height: 0;
+    background: var(--wp--preset--color--primary, #000);
+    transition: height 1s ease-out;
+}
+
+.stats-graph .label {
+    margin-top: 0.5rem;
+}
+
+.stats-graph .stat-number {
+    display: block;
+    font-size: 2rem;
+    font-weight: 700;
+}
+

--- a/src/scss/pages/_who-we-are.scss
+++ b/src/scss/pages/_who-we-are.scss
@@ -1,0 +1,31 @@
+.team-section .liquid-photo {
+    width: 150px;
+    height: 150px;
+    object-fit: cover;
+    border-radius: 40% 60% 70% 30% / 30% 40% 60% 70%;
+}
+
+.wt-carousel {
+    position: relative;
+}
+
+.wt-carousel figure {
+    display: none;
+    margin: 0;
+}
+
+.wt-carousel figure.active {
+    display: block;
+}
+
+.wt-carousel img {
+    width: 100%;
+    height: auto;
+}
+
+.wt-carousel figcaption {
+    text-align: center;
+    font-size: 0.9rem;
+    margin-top: 0.5rem;
+}
+

--- a/src/scss/pages/index.scss
+++ b/src/scss/pages/index.scss
@@ -1,0 +1,2 @@
+@forward "who-we-are";
+@forward "latest-project";

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,16 +4,16 @@
 <div class="wp-block-group alignwide home-top-menu">
     <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
     <div class="wp-block-buttons">
-        <!-- wp:button -->
-        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Who we are</a></div>
+        <!-- wp:button {"url":"/who-we-are"} -->
+        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/who-we-are">Who we are</a></div>
         <!-- /wp:button -->
 
-        <!-- wp:button -->
-        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Latest projects</a></div>
+        <!-- wp:button {"url":"/latest-project"} -->
+        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/latest-project">Latest project</a></div>
         <!-- /wp:button -->
 
-        <!-- wp:button -->
-        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Contact</a></div>
+        <!-- wp:button {"url":"/contact"} -->
+        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/contact">Contact</a></div>
         <!-- /wp:button -->
     </div>
     <!-- /wp:buttons -->

--- a/templates/page-contact.html
+++ b/templates/page-contact.html
@@ -1,0 +1,20 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+    <!-- wp:heading {"level":1,"align":"wide"} -->Contact<!-- /wp:heading -->
+
+    <!-- wp:group {"className":"contact-form","align":"wide"} -->
+    <div class="wp-block-group contact-form">
+        <form class="contact-form__form">
+            <p><label>Name<br /><input type="text" name="name" required></label></p>
+            <p><label>Email<br /><input type="email" name="email" required></label></p>
+            <p><button type="submit">Submit</button></p>
+        </form>
+    </div>
+    <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+

--- a/templates/page-latest-project.html
+++ b/templates/page-latest-project.html
@@ -1,0 +1,27 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+    <!-- wp:heading {"level":1,"align":"wide"} -->Latest project<!-- /wp:heading -->
+
+    <!-- wp:group {"className":"stats-graph","layout":{"type":"flex","justifyContent":"space-around","alignItems":"flex-end"}} -->
+    <div class="wp-block-group stats-graph">
+        <div class="stat" data-value="13">
+            <div class="bar"></div>
+            <div class="label"><span class="stat-number" data-target="13">0</span> customers</div>
+        </div>
+        <div class="stat" data-value="220000">
+            <div class="bar"></div>
+            <div class="label"><span class="stat-number" data-target="220000">0</span> USD in sales</div>
+        </div>
+        <div class="stat" data-value="4">
+            <div class="bar"></div>
+            <div class="label"><span class="stat-number" data-target="4">0</span> different countries</div>
+        </div>
+    </div>
+    <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+

--- a/templates/page-who-we-are.html
+++ b/templates/page-who-we-are.html
@@ -1,0 +1,43 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+    <!-- wp:heading {"level":1,"align":"wide"} -->Who we are<!-- /wp:heading -->
+
+    <!-- wp:group {"className":"team-section","layout":{"type":"flex","flexWrap":"wrap"}} -->
+    <div class="wp-block-group team-section">
+        <!-- wp:media-text {"mediaPosition":"left","mediaType":"image"} -->
+        <div class="wp-block-media-text is-stacked-on-mobile">
+            <figure class="wp-block-media-text__media"><img class="liquid-photo" src="https://picsum.photos/seed/team1/300/300" alt="Team member 1"/></figure>
+            <div class="wp-block-media-text__content">
+                <p>Developer and co-founder focused on crafting reliable solutions.</p>
+            </div>
+        </div>
+        <!-- /wp:media-text -->
+
+        <!-- wp:media-text {"mediaPosition":"left","mediaType":"image"} -->
+        <div class="wp-block-media-text is-stacked-on-mobile">
+            <figure class="wp-block-media-text__media"><img class="liquid-photo" src="https://picsum.photos/seed/team2/300/300" alt="Team member 2"/></figure>
+            <div class="wp-block-media-text__content">
+                <p>Designer and co-founder bringing ideas to life with thoughtful visuals.</p>
+            </div>
+        </div>
+        <!-- /wp:media-text -->
+    </div>
+    <!-- /wp:group -->
+
+    <!-- wp:group {"className":"worldwide-context"} -->
+    <div class="wp-block-group worldwide-context">
+        <!-- wp:heading {"level":2} -->Worldwide Context<!-- /wp:heading -->
+        <div class="wt-carousel">
+            <figure class="active"><img src="https://picsum.photos/seed/world1/800/400" alt="Slide 1" /><figcaption>Caption 1</figcaption></figure>
+            <figure><img src="https://picsum.photos/seed/world2/800/400" alt="Slide 2" /><figcaption>Caption 2</figcaption></figure>
+            <figure><img src="https://picsum.photos/seed/world3/800/400" alt="Slide 3" /><figcaption>Caption 3</figcaption></figure>
+        </div>
+    </div>
+    <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+


### PR DESCRIPTION
## Summary
- add navigation to contact, team, and latest project pages
- create pages with form, team info with carousel, and animated stats graph

## Testing
- `npm run build`
- `composer php-lint`
- `composer phpcs` *(fails: Missing @subpackage tag in inc/enqueue.php)*

------
https://chatgpt.com/codex/tasks/task_e_68a93a12b62c832db7887337f0bdfe8e