### PR TITLE
Add wave-shaped hero and marketing intro

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,26 +12,19 @@ Tags:
 Text Domain: block-theme
 */
 
-/* Make images with the wave-border class span the full width and add a simple wave at the bottom */
-.wave-border {
-    position: relative;
-    overflow: hidden;
-}
-
-.wave-border img {
+/* Styles for wave-shaped hero image and feature icons */
+.wave-border svg {
     width: 100%;
     height: auto;
     display: block;
 }
 
-.wave-border .wave {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 40px;
-}
-
-.wave-border .wave path {
-    fill: var(--wp--preset--color--background, #ffffff);
+.icon {
+    width: 64px;
+    height: 64px;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: var(--wp--preset--spacing--20);
+    color: var(--wp--preset--color--primary, #000);
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,42 +2,70 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-    <!-- wp:image {"sizeSlug":"large","linkDestination":"none","align":"full","className":"wave-border"} -->
-    <figure class="wp-block-image alignfull size-large wave-border"><img src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f" alt="Woman working at a computer"/><svg class="wave" viewBox="0 0 1440 80" preserveAspectRatio="none"><path d="M0 20 C80 0 160 40 240 20 S400 0 480 20 640 40 720 20 880 0 960 20 1120 40 1200 20 1360 0 1440 20 V80 H0 Z"/></svg></figure>
-    <!-- /wp:image -->
-
-    <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
-    <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)">
-        <!-- wp:heading -->
-        <h2>Section One</h2>
-        <!-- /wp:heading -->
-        <!-- wp:paragraph -->
-        <p>Content for the first section.</p>
-        <!-- /wp:paragraph -->
+    <!-- wp:group {"align":"full","className":"wave-border","layout":{"type":"default"}} -->
+    <div class="wp-block-group alignfull wave-border">
+        <!-- wp:html -->
+        <svg viewBox="0 0 1440 480" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
+            <defs>
+                <clipPath id="wave-clip">
+                    <path d="M0,0H1440V360C1120,320 960,400 720,360C480,320 240,400 0,360Z" />
+                </clipPath>
+            </defs>
+            <image href="https://images.unsplash.com/photo-1522202176988-66273c2fd55f" width="1440" height="480" clip-path="url(#wave-clip)" />
+        </svg>
+        <!-- /wp:html -->
     </div>
     <!-- /wp:group -->
 
-    <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
-    <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)">
-        <!-- wp:heading -->
-        <h2>Section Two</h2>
-        <!-- /wp:heading -->
-        <!-- wp:paragraph -->
-        <p>Content for the second section.</p>
-        <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:group -->
+    <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"1.5rem"},"spacing":{"margin":{"top":"var:preset|spacing|60"}}}} -->
+    <p class="has-text-align-center" style="margin-top:var(--wp--preset--spacing--60);font-size:1.5rem">We craft digital marketing experiences that help small businesses grow and connect with their customers.</p>
+    <!-- /wp:paragraph -->
 
-    <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
-    <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)">
-        <!-- wp:heading -->
-        <h2>Section Three</h2>
-        <!-- /wp:heading -->
-        <!-- wp:paragraph -->
-        <p>Content for the third section.</p>
-        <!-- /wp:paragraph -->
+    <!-- wp:columns {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}}} -->
+    <div class="wp-block-columns" style="margin-top:var(--wp--preset--spacing--60)">
+        <!-- wp:column -->
+        <div class="wp-block-column">
+            <!-- wp:html -->
+            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="7" r="4"/><path d="M5.5 21a8.38 8.38 0 0 1 13 0"/></svg>
+            <!-- /wp:html -->
+            <!-- wp:heading {"textAlign":"center","level":3} -->
+            <h3 class="has-text-align-center">Who I Am</h3>
+            <!-- /wp:heading -->
+            <!-- wp:paragraph {"align":"center"} -->
+            <p class="has-text-align-center">A dedicated marketer passionate about elevating small businesses.</p>
+            <!-- /wp:paragraph -->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column -->
+        <div class="wp-block-column">
+            <!-- wp:html -->
+            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l3 7h7l-5.5 4.5L19 21l-7-4-7 4 1.5-7.5L2 9h7z"/></svg>
+            <!-- /wp:html -->
+            <!-- wp:heading {"textAlign":"center","level":3} -->
+            <h3 class="has-text-align-center">What I Do</h3>
+            <!-- /wp:heading -->
+            <!-- wp:paragraph {"align":"center"} -->
+            <p class="has-text-align-center">Strategic campaigns and content that turn clicks into customers.</p>
+            <!-- /wp:paragraph -->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column -->
+        <div class="wp-block-column">
+            <!-- wp:html -->
+            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 13h2v5H7zM11 9h2v9h-2zM15 5h2v13h-2z"/></svg>
+            <!-- /wp:html -->
+            <!-- wp:heading {"textAlign":"center","level":3} -->
+            <h3 class="has-text-align-center">Results</h3>
+            <!-- /wp:heading -->
+            <!-- wp:paragraph {"align":"center"} -->
+            <p class="has-text-align-center">Data-driven outcomes that grow your revenue and reach.</p>
+            <!-- /wp:paragraph -->
+        </div>
+        <!-- /wp:column -->
     </div>
-    <!-- /wp:group -->
+    <!-- /wp:columns -->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## Summary
- Transform home template image into wave-clipped hero
- Add digital marketing agency intro and three concept sections
- Style wave hero and icons

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad7c1344bc832dbf57c220a6dc39a8