### PR TITLE
Add hero image and logo carousel to home page

### DIFF
--- a/assets/images/logo1.svg
+++ b/assets/images/logo1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">
+  <rect width="120" height="60" fill="#3858e9"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="#ffffff">Logo 1</text>
+</svg>

--- a/assets/images/logo2.svg
+++ b/assets/images/logo2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">
+  <rect width="120" height="60" fill="#7b90ff"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="#ffffff">Logo 2</text>
+</svg>

--- a/assets/images/logo3.svg
+++ b/assets/images/logo3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">
+  <rect width="120" height="60" fill="#181a1f"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="#ffffff">Logo 3</text>
+</svg>

--- a/style.css
+++ b/style.css
@@ -11,3 +11,29 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Tags:
 Text Domain: block-theme
 */
+
+.home-hero img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.logo-carousel {
+  display: flex;
+  overflow: hidden;
+  gap: 2rem;
+  animation: scroll-logos 20s linear infinite;
+}
+.logo-carousel img {
+  height: 60px;
+  width: auto;
+  flex-shrink: 0;
+}
+@keyframes scroll-logos {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,34 +1,79 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
+<!-- wp:image {"align":"full","sizeSlug":"full","linkDestination":"none","className":"home-hero"} -->
+<figure class="wp-block-image alignfull size-full home-hero"><img src="/wp-content/themes/block-theme/screenshot.png" alt="Home image"/></figure>
+<!-- /wp:image -->
+
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--70)">
-	<!-- wp:site-title {"style":{"spacing":{"margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}}, "align":"wide"} /-->
+        <!-- wp:site-title {"style":{"spacing":{"margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"align":"wide"} /-->
 
-	<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->
-	<div class="wp-block-query alignwide">
-		<!-- wp:post-template {"align":"wide"} -->
-			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"clamp(15vw, 30vh, 400px)","align":"wide"} /-->
-			<!-- wp:post-title {"isLink":true} /-->
-			<!-- wp:post-excerpt /-->
-			<!-- wp:post-date {"isLink":true} /-->
+        <!-- wp:group {"align":"full","style":{"color":{"background":"#ffffff"},"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
+        <div class="wp-block-group alignfull has-background" style="background-color:#ffffff;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+                <!-- wp:columns {"align":"wide"} -->
+                <div class="wp-block-columns alignwide">
+                        <!-- wp:column -->
+                        <div class="wp-block-column"><!-- wp:heading {"level":3} --><h3>Who I Am</h3><!-- /wp:heading --><p>Short description.</p></div>
+                        <!-- /wp:column -->
+                        <!-- wp:column -->
+                        <div class="wp-block-column"><!-- wp:heading {"level":3} --><h3>What I Do</h3><!-- /wp:heading --><p>Short description.</p></div>
+                        <!-- /wp:column -->
+                        <!-- wp:column -->
+                        <div class="wp-block-column"><!-- wp:heading {"level":3} --><h3>What I Love</h3><!-- /wp:heading --><p>Short description.</p></div>
+                        <!-- /wp:column -->
+                </div>
+                <!-- /wp:columns -->
 
-			<!-- wp:spacer {"height":"var(--wp--preset--spacing--40)"} -->
-			<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
-			<!-- /wp:spacer -->
-		<!-- /wp:post-template -->
+                <!-- wp:group {"className":"logo-carousel"} -->
+                <div class="wp-block-group logo-carousel">
+                        <!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+                        <figure class="wp-block-image size-full"><img src="/wp-content/themes/block-theme/assets/images/logo1.svg" alt="Logo 1"/></figure>
+                        <!-- /wp:image -->
+                        <!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+                        <figure class="wp-block-image size-full"><img src="/wp-content/themes/block-theme/assets/images/logo2.svg" alt="Logo 2"/></figure>
+                        <!-- /wp:image -->
+                        <!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+                        <figure class="wp-block-image size-full"><img src="/wp-content/themes/block-theme/assets/images/logo3.svg" alt="Logo 3"/></figure>
+                        <!-- /wp:image -->
+                        <!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+                        <figure class="wp-block-image size-full"><img src="/wp-content/themes/block-theme/assets/images/logo1.svg" alt="Logo 1"/></figure>
+                        <!-- /wp:image -->
+                        <!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+                        <figure class="wp-block-image size-full"><img src="/wp-content/themes/block-theme/assets/images/logo2.svg" alt="Logo 2"/></figure>
+                        <!-- /wp:image -->
+                        <!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+                        <figure class="wp-block-image size-full"><img src="/wp-content/themes/block-theme/assets/images/logo3.svg" alt="Logo 3"/></figure>
+                        <!-- /wp:image -->
+                </div>
+                <!-- /wp:group -->
+        </div>
+        <!-- /wp:group -->
 
-		<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-			<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
-			<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-		<!-- /wp:query-pagination -->
-	</div>
-	<!-- /wp:query -->
+        <!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->
+        <div class="wp-block-query alignwide">
+                <!-- wp:post-template {"align":"wide"} -->
+                        <!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"clamp(15vw, 30vh, 400px)","align":"wide"} /-->
+                        <!-- wp:post-title {"isLink":true} /-->
+                        <!-- wp:post-excerpt /-->
+                        <!-- wp:post-date {"isLink":true} /-->
 
-	<!-- wp:spacer {"height":"var(--wp--preset--spacing--60)"} -->
-	<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
+                        <!-- wp:spacer {"height":"var(--wp--preset--spacing--40)"} -->
+                        <div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
+                        <!-- /wp:spacer -->
+                <!-- /wp:post-template -->
 
-	<!-- wp:pattern {"slug":"block-theme/call-to-action"} /-->
+                <!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+                        <!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
+                        <!-- wp:query-pagination-next {"label":"Older Posts"} /-->
+                <!-- /wp:query-pagination -->
+        </div>
+        <!-- /wp:query -->
+
+        <!-- wp:spacer {"height":"var:preset|spacing|60"} -->
+        <div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer"></div>
+        <!-- /wp:spacer -->
+
+        <!-- wp:pattern {"slug":"block-theme/call-to-action"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## Summary
- add full-width hero image to home template
- introduce white concepts section with scrolling logo carousel
- style hero and carousel for responsiveness

## Testing
- `npm run build`
- `composer run php-lint`
- `composer run phpcs` *(fails: WordPress sniff internal errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b009393e38832dba914e2546a2f4fa