### PR TITLE
Add responsive wave hero and logo carousel

### DIFF
--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+	const slides = document.querySelectorAll('.logo-carousel .logo-slide');
+	let index = 0;
+
+	if (slides.length > 0) {
+		slides[index].classList.add('active');
+
+		setInterval(() => {
+			slides[index].classList.remove('active');
+			index = (index + 1) % slides.length;
+			slides[index].classList.add('active');
+		}, 3000);
+	}
+});

--- a/src/scss/components/home.scss
+++ b/src/scss/components/home.scss
@@ -1,0 +1,26 @@
+.wave-border svg {
+	width: 100%;
+	height: auto;
+	display: block;
+}
+
+.logo-carousel {
+	position: relative;
+	width: 100%;
+	max-width: 100%;
+	overflow: hidden;
+	text-align: center;
+}
+
+.logo-slide {
+	display: none;
+}
+
+.logo-slide img {
+	max-width: 100%;
+	height: auto;
+}
+
+.logo-slide.active {
+	display: block;
+}

--- a/src/scss/components/index.scss
+++ b/src/scss/components/index.scss
@@ -1,0 +1,1 @@
+@forward "home";

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,72 +2,169 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-    <!-- wp:group {"align":"full","className":"wave-border","layout":{"type":"default"}} -->
-    <div class="wp-block-group alignfull wave-border">
-        <!-- wp:html -->
-        <svg viewBox="0 0 1440 480" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
-            <defs>
-                <clipPath id="wave-clip">
-                    <path d="M0,0H1440V360C1120,320 960,400 720,360C480,320 240,400 0,360Z" />
-                </clipPath>
-            </defs>
-            <image href="https://images.unsplash.com/photo-1522202176988-66273c2fd55f" width="1440" height="480" clip-path="url(#wave-clip)" />
-        </svg>
-        <!-- /wp:html -->
-    </div>
-    <!-- /wp:group -->
+	<!-- wp:group {"align":"full","className":"wave-border","layout":{"type":"default"}} -->
+	<div class="wp-block-group alignfull wave-border">
+		<!-- wp:html -->
+		<svg
+			viewBox="0 0 1440 480"
+			xmlns="http://www.w3.org/2000/svg"
+			preserveAspectRatio="xMidYMid slice"
+		>
+			<defs>
+				<clipPath id="wave-clip">
+					<path
+						d="M0,0H1440V360C1120,320 960,400 720,360C480,320 240,400 0,360Z"
+					/>
+				</clipPath>
+			</defs>
+			<image
+				href="https://images.unsplash.com/photo-1522202176988-66273c2fd55f"
+				width="100%"
+				height="100%"
+				clip-path="url(#wave-clip)"
+				preserveAspectRatio="xMidYMid slice"
+			/>
+		</svg>
+		<!-- /wp:html -->
+	</div>
+	<!-- /wp:group -->
 
-    <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"1.5rem"},"spacing":{"margin":{"top":"var:preset|spacing|60"}}}} -->
-    <p class="has-text-align-center" style="margin-top:var(--wp--preset--spacing--60);font-size:1.5rem">We craft digital marketing experiences that help small businesses grow and connect with their customers.</p>
-    <!-- /wp:paragraph -->
+	<!-- wp:group {"align":"full","style":{"color":{"background":"#FFFFFF","text":"var:preset|color|background"},"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
+	<div
+		class="wp-block-group alignfull concept-section"
+		style="
+			color: var(--wp--preset--color--background);
+			background-color: #ffffff;
+			padding-top: var(--wp--preset--spacing--60);
+			padding-bottom: var(--wp--preset--spacing--60);
+		"
+	>
+		<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"1.5rem"}}} -->
+		<p class="has-text-align-center" style="font-size: 1.5rem">
+			We craft digital marketing experiences that help small businesses
+			grow and connect with their customers.
+		</p>
+		<!-- /wp:paragraph -->
 
-    <!-- wp:columns {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}}} -->
-    <div class="wp-block-columns" style="margin-top:var(--wp--preset--spacing--60)">
-        <!-- wp:column -->
-        <div class="wp-block-column">
-            <!-- wp:html -->
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="7" r="4"/><path d="M5.5 21a8.38 8.38 0 0 1 13 0"/></svg>
-            <!-- /wp:html -->
-            <!-- wp:heading {"textAlign":"center","level":3} -->
-            <h3 class="has-text-align-center">Who I Am</h3>
-            <!-- /wp:heading -->
-            <!-- wp:paragraph {"align":"center"} -->
-            <p class="has-text-align-center">A dedicated marketer passionate about elevating small businesses.</p>
-            <!-- /wp:paragraph -->
-        </div>
-        <!-- /wp:column -->
+		<!-- wp:columns {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}}} -->
+		<div
+			class="wp-block-columns"
+			style="margin-top: var(--wp--preset--spacing--60)"
+		>
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:html -->
+				<svg
+					class="icon"
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<circle cx="12" cy="7" r="4" />
+					<path d="M5.5 21a8.38 8.38 0 0 1 13 0" />
+				</svg>
+				<!-- /wp:html -->
+				<!-- wp:heading {"textAlign":"center","level":3} -->
+				<h3 class="has-text-align-center">Who I Am</h3>
+				<!-- /wp:heading -->
+				<!-- wp:paragraph {"align":"center"} -->
+				<p class="has-text-align-center">
+					A dedicated marketer passionate about elevating small
+					businesses.
+				</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:column -->
 
-        <!-- wp:column -->
-        <div class="wp-block-column">
-            <!-- wp:html -->
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l3 7h7l-5.5 4.5L19 21l-7-4-7 4 1.5-7.5L2 9h7z"/></svg>
-            <!-- /wp:html -->
-            <!-- wp:heading {"textAlign":"center","level":3} -->
-            <h3 class="has-text-align-center">What I Do</h3>
-            <!-- /wp:heading -->
-            <!-- wp:paragraph {"align":"center"} -->
-            <p class="has-text-align-center">Strategic campaigns and content that turn clicks into customers.</p>
-            <!-- /wp:paragraph -->
-        </div>
-        <!-- /wp:column -->
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:html -->
+				<svg
+					class="icon"
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path
+						d="M12 2l3 7h7l-5.5 4.5L19 21l-7-4-7 4 1.5-7.5L2 9h7z"
+					/>
+				</svg>
+				<!-- /wp:html -->
+				<!-- wp:heading {"textAlign":"center","level":3} -->
+				<h3 class="has-text-align-center">What I Do</h3>
+				<!-- /wp:heading -->
+				<!-- wp:paragraph {"align":"center"} -->
+				<p class="has-text-align-center">
+					Strategic campaigns and content that turn clicks into
+					customers.
+				</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:column -->
 
-        <!-- wp:column -->
-        <div class="wp-block-column">
-            <!-- wp:html -->
-            <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 13h2v5H7zM11 9h2v9h-2zM15 5h2v13h-2z"/></svg>
-            <!-- /wp:html -->
-            <!-- wp:heading {"textAlign":"center","level":3} -->
-            <h3 class="has-text-align-center">Results</h3>
-            <!-- /wp:heading -->
-            <!-- wp:paragraph {"align":"center"} -->
-            <p class="has-text-align-center">Data-driven outcomes that grow your revenue and reach.</p>
-            <!-- /wp:paragraph -->
-        </div>
-        <!-- /wp:column -->
-    </div>
-    <!-- /wp:columns -->
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:html -->
+				<svg
+					class="icon"
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path d="M3 3v18h18" />
+					<path d="M7 13h2v5H7zM11 9h2v9h-2zM15 5h2v13h-2z" />
+				</svg>
+				<!-- /wp:html -->
+				<!-- wp:heading {"textAlign":"center","level":3} -->
+				<h3 class="has-text-align-center">Results</h3>
+				<!-- /wp:heading -->
+				<!-- wp:paragraph {"align":"center"} -->
+				<p class="has-text-align-center">
+					Data-driven outcomes that grow your revenue and reach.
+				</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:column -->
+		</div>
+		<!-- /wp:columns -->
+
+		<!-- wp:html -->
+		<div class="logo-carousel">
+			<div class="logo-slide">
+				<img
+					src="https://via.placeholder.com/150x80?text=Logo+1"
+					alt="Logo 1"
+				/>
+			</div>
+			<div class="logo-slide">
+				<img
+					src="https://via.placeholder.com/150x80?text=Logo+2"
+					alt="Logo 2"
+				/>
+			</div>
+			<div class="logo-slide">
+				<img
+					src="https://via.placeholder.com/150x80?text=Logo+3"
+					alt="Logo 3"
+				/>
+			</div>
+		</div>
+		<!-- /wp:html -->
+	</div>
+	<!-- /wp:group -->
 </main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
-


### PR DESCRIPTION
## Summary
- make hero wave image responsive and full-width
- add white concept section with rotating logo carousel
- include styling and script for carousel behavior

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b00f0540f8832d8b3c3c0e46e54c2a