### PR TITLE
Refine home layout and add logo carousel

### DIFF
--- a/src/scss/components/home.scss
+++ b/src/scss/components/home.scss
@@ -1,15 +1,32 @@
+body {
+        background-color: #ffffff;
+        color: #000000;
+}
+
+.wave-border {
+        background-color: #ffffff;
+}
+
 .wave-border svg {
-	width: 100%;
-	height: auto;
-	display: block;
+        width: 100%;
+        height: auto;
+        display: block;
+}
+
+.icon {
+        width: 64px;
+        height: 64px;
+        display: block;
+        margin: 3cm;
+        color: var(--wp--preset--color--primary, #000);
 }
 
 .logo-carousel {
-	position: relative;
-	width: 100%;
-	max-width: 100%;
-	overflow: hidden;
-	text-align: center;
+        position: relative;
+        width: 100%;
+        max-width: 100%;
+        overflow: hidden;
+        text-align: center;
 }
 
 .logo-slide {

--- a/style.css
+++ b/style.css
@@ -12,7 +12,16 @@ Tags:
 Text Domain: block-theme
 */
 
-/* Styles for wave-shaped hero image and feature icons */
+/* Styles for wave-shaped hero image, icons, and logo carousel */
+body {
+    background-color: #ffffff;
+    color: #000000;
+}
+
+.wave-border {
+    background-color: #ffffff;
+}
+
 .wave-border svg {
     width: 100%;
     height: auto;
@@ -23,8 +32,27 @@ Text Domain: block-theme
     width: 64px;
     height: 64px;
     display: block;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: var(--wp--preset--spacing--20);
+    margin: 3cm;
     color: var(--wp--preset--color--primary, #000);
+}
+
+.logo-carousel {
+    position: relative;
+    width: 100%;
+    max-width: 100%;
+    overflow: hidden;
+    text-align: center;
+}
+
+.logo-slide {
+    display: none;
+}
+
+.logo-slide img {
+    max-width: 100%;
+    height: auto;
+}
+
+.logo-slide.active {
+    display: block;
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,13 +3,13 @@
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
 	<!-- wp:group {"align":"full","className":"wave-border","layout":{"type":"default"}} -->
-	<div class="wp-block-group alignfull wave-border">
-		<!-- wp:html -->
-		<svg
-			viewBox="0 0 1440 480"
-			xmlns="http://www.w3.org/2000/svg"
-			preserveAspectRatio="xMidYMid slice"
-		>
+        <div class="wp-block-group alignfull wave-border">
+                <!-- wp:html -->
+                <svg
+                        viewBox="0 0 1440 480"
+                        xmlns="http://www.w3.org/2000/svg"
+                        preserveAspectRatio="xMidYMid meet"
+                >
 			<defs>
 				<clipPath id="wave-clip">
 					<path
@@ -17,28 +17,28 @@
 					/>
 				</clipPath>
 			</defs>
-			<image
-				href="https://images.unsplash.com/photo-1522202176988-66273c2fd55f"
-				width="100%"
-				height="100%"
-				clip-path="url(#wave-clip)"
-				preserveAspectRatio="xMidYMid slice"
-			/>
-		</svg>
-		<!-- /wp:html -->
-	</div>
-	<!-- /wp:group -->
+                        <image
+                                href="https://images.unsplash.com/photo-1522202176988-66273c2fd55f"
+                                width="100%"
+                                height="100%"
+                                clip-path="url(#wave-clip)"
+                                preserveAspectRatio="xMidYMid meet"
+                        />
+                </svg>
+                <!-- /wp:html -->
+        </div>
+        <!-- /wp:group -->
 
-	<!-- wp:group {"align":"full","style":{"color":{"background":"#FFFFFF","text":"var:preset|color|background"},"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
+        <!-- wp:group {"align":"full","style":{"color":{"background":"#FFFFFF","text":"#000000"},"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
 	<div
 		class="wp-block-group alignfull concept-section"
 		style="
-			color: var(--wp--preset--color--background);
-			background-color: #ffffff;
-			padding-top: var(--wp--preset--spacing--60);
-			padding-bottom: var(--wp--preset--spacing--60);
-		"
-	>
+                        color: #000000;
+                        background-color: #ffffff;
+                        padding-top: var(--wp--preset--spacing--60);
+                        padding-bottom: var(--wp--preset--spacing--60);
+                "
+        >
 		<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"1.5rem"}}} -->
 		<p class="has-text-align-center" style="font-size: 1.5rem">
 			We craft digital marketing experiences that help small businesses
@@ -54,20 +54,16 @@
 			<!-- wp:column -->
 			<div class="wp-block-column">
 				<!-- wp:html -->
-				<svg
-					class="icon"
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-				>
-					<circle cx="12" cy="7" r="4" />
-					<path d="M5.5 21a8.38 8.38 0 0 1 13 0" />
-				</svg>
-				<!-- /wp:html -->
+                                <svg
+                                        class="icon"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 24 24"
+                                        fill="currentColor"
+                                        stroke="none"
+                                >
+                                        <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+                                </svg>
+                                <!-- /wp:html -->
 				<!-- wp:heading {"textAlign":"center","level":3} -->
 				<h3 class="has-text-align-center">Who I Am</h3>
 				<!-- /wp:heading -->
@@ -83,21 +79,16 @@
 			<!-- wp:column -->
 			<div class="wp-block-column">
 				<!-- wp:html -->
-				<svg
-					class="icon"
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-				>
-					<path
-						d="M12 2l3 7h7l-5.5 4.5L19 21l-7-4-7 4 1.5-7.5L2 9h7z"
-					/>
-				</svg>
-				<!-- /wp:html -->
+                                <svg
+                                        class="icon"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 24 24"
+                                        fill="currentColor"
+                                        stroke="none"
+                                >
+                                        <path d="M12 17.27L18.18 21 16.54 13.97 22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z" />
+                                </svg>
+                                <!-- /wp:html -->
 				<!-- wp:heading {"textAlign":"center","level":3} -->
 				<h3 class="has-text-align-center">What I Do</h3>
 				<!-- /wp:heading -->
@@ -113,20 +104,16 @@
 			<!-- wp:column -->
 			<div class="wp-block-column">
 				<!-- wp:html -->
-				<svg
-					class="icon"
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-				>
-					<path d="M3 3v18h18" />
-					<path d="M7 13h2v5H7zM11 9h2v9h-2zM15 5h2v13h-2z" />
-				</svg>
-				<!-- /wp:html -->
+                                <svg
+                                        class="icon"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 24 24"
+                                        fill="currentColor"
+                                        stroke="none"
+                                >
+                                        <path d="M3 3h2v18H3V3zm4 10h2v8H7v-8zm4-4h2v12h-2V9zm4-4h2v16h-2V5zm4-4h2v20h-2V1z" />
+                                </svg>
+                                <!-- /wp:html -->
 				<!-- wp:heading {"textAlign":"center","level":3} -->
 				<h3 class="has-text-align-center">Results</h3>
 				<!-- /wp:heading -->
@@ -161,9 +148,38 @@
 				/>
 			</div>
 		</div>
-		<!-- /wp:html -->
-	</div>
-	<!-- /wp:group -->
+                <!-- /wp:html -->
+                <!-- wp:html -->
+                <script>
+                document.addEventListener('DOMContentLoaded', function() {
+                        const slides = document.querySelectorAll('.logo-slide');
+                        let index = 0;
+                        function showSlide(i) {
+                                slides.forEach((s, n) => {
+                                        s.classList.toggle('active', n === i);
+                                });
+                        }
+                        function nextSlide() {
+                                index = (index + 1) % slides.length;
+                                showSlide(index);
+                        }
+                        showSlide(index);
+                        setInterval(nextSlide, 3000);
+                });
+                </script>
+                <!-- /wp:html -->
+        </div>
+        <!-- /wp:group -->
+
+        <!-- wp:group {"align":"full","className":"orange-section","style":{"color":{"background":"#E06547"}}} -->
+        <div class="wp-block-group alignfull orange-section" style="background-color: #E06547">
+                <!-- wp:html -->
+                <svg viewBox="0 0 1440 80" xmlns="http://www.w3.org/2000/svg">
+                        <path fill="#ffffff" d="M0,0H1440V40C960,80 480,0 0,40Z" />
+                </svg>
+                <!-- /wp:html -->
+        </div>
+        <!-- /wp:group -->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## Summary
- Show hero image without cropping and remove orange band below wave
- Add auto-rotating logo carousel and restyle feature icons with generous margins
- Append decorative orange wave section after feature icons

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b01835e0dc832dad394ec8db34a73f