### PR TITLE
Add hero section with wave divider

### DIFF
--- a/src/scss/components/home.scss
+++ b/src/scss/components/home.scss
@@ -1,16 +1,81 @@
 body {
-        background-color: #ffffff;
-        color: #000000;
+background-color: #ffffff;
+color: #000000;
 }
 
-.wave-border {
-        background-color: #ffffff;
+.hero-section {
+position: relative;
+background-size: cover;
+background-position: center;
+display: flex;
+flex-direction: column;
+justify-content: center;
+align-items: center;
+text-align: center;
+min-height: 80vh;
+color: #ffffff;
 }
 
-.wave-border svg {
-        width: 100%;
-        height: auto;
-        display: block;
+@media (max-width: 768px) {
+.hero-section {
+min-height: 70vh;
+}
+}
+
+.hero-section::before {
+content: "";
+position: absolute;
+top: 0;
+left: 0;
+right: 0;
+bottom: 0;
+background: rgba(0, 0, 0, 0.35);
+z-index: 0;
+}
+
+.hero-section .hero-content {
+position: relative;
+z-index: 1;
+padding: 0 1rem;
+max-width: 800px;
+margin: 0 auto;
+}
+
+.hero-section h1 {
+color: #ffffff;
+font-weight: 700;
+font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.hero-section p {
+color: #ffffff;
+font-size: clamp(1rem, 3vw, 1.5rem);
+}
+
+.hero-button .wp-block-button__link {
+background: #ffffff;
+color: #E06547;
+border-radius: 9999px;
+padding: 1rem 2rem;
+transition: background-color 0.3s ease, color 0.3s ease;
+text-decoration: none;
+border: none;
+box-shadow: none;
+}
+
+.hero-button .wp-block-button__link:hover {
+background: #E06547;
+color: #ffffff;
+}
+
+.hero-wave {
+position: absolute;
+bottom: 0;
+left: 0;
+width: 100%;
+height: auto;
+display: block;
+line-height: 0;
 }
 
 .icon {

--- a/style.css
+++ b/style.css
@@ -18,16 +18,6 @@ body {
     color: #000000;
 }
 
-.wave-border {
-    background-color: #ffffff;
-}
-
-.wave-border svg {
-    width: 100%;
-    height: auto;
-    display: block;
-}
-
 .icon {
     width: 64px;
     height: 64px;
@@ -55,4 +45,79 @@ body {
 
 .logo-slide.active {
     display: block;
+}
+
+.hero-section {
+    position: relative;
+    background-size: cover;
+    background-position: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    min-height: 80vh;
+    color: #ffffff;
+}
+
+@media (max-width: 768px) {
+    .hero-section {
+        min-height: 70vh;
+    }
+}
+
+.hero-section::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 0;
+}
+
+.hero-section .hero-content {
+    position: relative;
+    z-index: 1;
+    padding: 0 1rem;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.hero-section h1 {
+    color: #ffffff;
+    font-weight: 700;
+    font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.hero-section p {
+    color: #ffffff;
+    font-size: clamp(1rem, 3vw, 1.5rem);
+}
+
+.hero-button .wp-block-button__link {
+    background: #ffffff;
+    color: #E06547;
+    border-radius: 9999px;
+    padding: 1rem 2rem;
+    transition: background-color 0.3s ease, color 0.3s ease;
+    text-decoration: none;
+    border: none;
+    box-shadow: none;
+}
+
+.hero-button .wp-block-button__link:hover {
+    background: #E06547;
+    color: #ffffff;
+}
+
+.hero-wave {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: auto;
+    display: block;
+    line-height: 0;
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,29 +2,25 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:group {"align":"full","className":"wave-border","layout":{"type":"default"}} -->
-        <div class="wp-block-group alignfull wave-border">
+        <!-- wp:group {"align":"full","className":"hero-section","style":{"color":{"text":"#ffffff"}},"layout":{"type":"default"}} -->
+        <div class="wp-block-group alignfull hero-section" style="background-image:url('https://images.unsplash.com/photo-1521791136064-7986c2920216?auto=format&fit=crop&w=1770&q=80');color:#ffffff;">
+                <div class="hero-content">
+                        <!-- wp:heading {"textAlign":"center","level":1} -->
+                        <h1 class="has-text-align-center">Digital Marketing that Helps Small Businesses Grow</h1>
+                        <!-- /wp:heading -->
+                        <!-- wp:paragraph {"align":"center"} -->
+                        <p class="has-text-align-center">We make marketing fun, effective, and stress-free—so you can focus on your business.</p>
+                        <!-- /wp:paragraph -->
+                        <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+                        <div class="wp-block-buttons">
+                                <!-- wp:button {"className":"hero-button"} -->
+                                <div class="wp-block-button hero-button"><a class="wp-block-button__link">Get Your Free Consultation</a></div>
+                                <!-- /wp:button -->
+                        </div>
+                        <!-- /wp:buttons -->
+                </div>
                 <!-- wp:html -->
-                <svg
-                        viewBox="0 0 1440 480"
-                        xmlns="http://www.w3.org/2000/svg"
-                        preserveAspectRatio="xMidYMid meet"
-                >
-			<defs>
-				<clipPath id="wave-clip">
-					<path
-						d="M0,0H1440V360C1120,320 960,400 720,360C480,320 240,400 0,360Z"
-					/>
-				</clipPath>
-			</defs>
-                        <image
-                                href="https://images.unsplash.com/photo-1522202176988-66273c2fd55f"
-                                width="100%"
-                                height="100%"
-                                clip-path="url(#wave-clip)"
-                                preserveAspectRatio="xMidYMid meet"
-                        />
-                </svg>
+                <svg class="hero-wave" viewBox="0 0 1440 80" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none"><path fill="#ffffff" d="M0,0H1440V40C960,80 480,0 0,40Z"/></svg>
                 <!-- /wp:html -->
         </div>
         <!-- /wp:group -->


### PR DESCRIPTION
## Summary
- Adjust hero section height and overlay opacity for "Enjoy Marketing" home page
- Invert CTA button colors with pill shape and hover effect
- Ensure bottom wave divider renders cleanly across breakpoints

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b01e3b8da0832d98ec54fee41c2fc4